### PR TITLE
FixMojo: don't IOOB when dependencies starts with test or ends with n…

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/FixMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/FixMojo.java
@@ -189,7 +189,12 @@ public class FixMojo
     List<Dependency> nonTestDependencies = consecutiveNonTestDeps( localDependencies );
 
     final int backupTestIndex;
-    if ( testDependencies.isEmpty() )
+    if ( testDependencies.isEmpty() && nonTestDependencies.isEmpty() )
+    {
+      Dependency lastDep = sortByLineNumberDescending( localDependencies ).get( 0 );
+      backupTestIndex = lineIndexAfter( lastDep, pomLines );
+    }
+    else if ( testDependencies.isEmpty() )
     {
       Dependency lastDep = sortByLineNumberDescending( nonTestDependencies ).get( 0 );
       backupTestIndex = lineIndexAfter( lastDep, pomLines );
@@ -201,7 +206,12 @@ public class FixMojo
     }
 
     final int backupNonTestIndex;
-    if ( nonTestDependencies.isEmpty() )
+    if ( testDependencies.isEmpty() && nonTestDependencies.isEmpty() )
+    {
+      Dependency firstDep = sortByLineNumberAscending( localDependencies ).get( 0 );
+      backupNonTestIndex = lineIndexAfter( firstDep, pomLines );
+    }
+    else if ( nonTestDependencies.isEmpty() )
     {
       Dependency firstTestDep = sortByLineNumberAscending( testDependencies ).get( 0 );
       backupNonTestIndex = startIndex( firstTestDep );


### PR DESCRIPTION
…on-test

This was resulting in errors in file where the first dep had scope `test` and the last had scope `compile`.

@jhaber @kmclarnon
