### PR TITLE
Temporarily ignore unused immutables exceptions deps

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
@@ -393,7 +393,9 @@ public abstract class AbstractAnalyzeMojo
         );
 
         ignoredUnusedDeclared.addAll( filterDependencies( unusedDeclared, ignoredDependencies ) );
-        ignoredUnusedDeclared.addAll( filterDependencies( unusedDeclared, ignoredUnusedDeclaredDependencies ) );
+        String[] tmp = Arrays.copyOf(ignoredUnusedDeclaredDependencies, ignoredUnusedDeclaredDependencies.length + 1);
+        tmp[tmp.length - 1] = "com.hubspot.immutables:immutables-exceptions";
+        ignoredUnusedDeclared.addAll( filterDependencies( unusedDeclared, tmp ) );
 
         boolean reported = false;
         boolean warning = false;


### PR DESCRIPTION
Temporarily hardcodes this into the plugin so we can later fix usages of these with the dependency fixer.

cc @kmclarnon @stevegutz @jhaber 