### PR TITLE
switch back to default hubspot branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-dependency-analyzer</artifactId>
-      <version>1.13.3-hubspot-rebase-SNAPSHOT</version>
+      <version>1.13.3-hubspot-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>


### PR DESCRIPTION
move back to the default `hubspot` branch of `maven-dependency-analyzer`

@PtrTeixeira @ggs5427 