### PR TITLE
Upgrade dependency-analyzer to 1.14.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-dependency-analyzer</artifactId>
-      <version>1.13.3-hubspot-SNAPSHOT</version>
+      <version>1.14.1-hubspot-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
@@ -373,9 +373,9 @@ under the License.
           <configuration>
             <excludes combine.children="append">
               <!--
-                              These files contain results for integration tests which can't contain license header
-                              otherwise the IT's will fail.
-                            -->
+                                            These files contain results for integration tests which can't contain license header
+                                            otherwise the IT's will fail.
+                                          -->
               <exclude>src/it/projects/tree/expected.txt</exclude>
               <exclude>src/it/projects/tree-includes/expected.txt</exclude>
               <exclude>src/it/projects/tree-multimodule/expected.txt</exclude>
@@ -389,13 +389,13 @@ under the License.
               <!-- These files contain expected versions for unit tests -->
               <exclude>src/test/resources/unit/verbose-serializer-test/*</exclude>
               <!--
-                              These files contain real repository artifacts.
-                            -->
+                                            These files contain real repository artifacts.
+                                          -->
               <exclude>src/test/resources/unit/get-test/repository/test/test/1.0/test-1.0.jar.sha1</exclude>
               <exclude>src/test/resources/unit/get-test/repository/test/test/1.0/test-1.0.pom.sha1</exclude>
               <!--
-                              Files with test data.
-                            -->
+                                            Files with test data.
+                                          -->
               <exclude>src/test/resources/unit/list-test/testListClasses*.txt</exclude>
             </excludes>
           </configuration>


### PR DESCRIPTION
Also sets compilation JDK to 17, for a spotless compatibility issue with 21.