### PR TITLE
Don't suggest provided scope in dependency xml

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
@@ -563,7 +563,8 @@ public abstract class AbstractAnalyzeMojo extends AbstractMojo {
                     writer.endElement();
                 }
 
-                if (!Artifact.SCOPE_COMPILE.equals(artifact.getScope())) {
+                if (!Artifact.SCOPE_COMPILE.equals(artifact.getScope())
+                  && !Artifact.SCOPE_PROVIDED.equals(artifact.getScope())) {
                     writer.startElement("scope");
                     writer.writeText(artifact.getScope());
                     writer.endElement();


### PR DESCRIPTION
We have _a lot_ of internal dependencies that are incorrectly at `provided` scope. After seeing that many of them were added via sirjester, I decided to make this change.

I think that in the vast majority of cases we will want these dependencies to be at `compile` scope. I think that if a dependency is coming in transitively via a provided dep, then we probably actually want it at `compile` scope. It's possible I'm overlooking something, but I think that this PR is still an improvement overall.

@jaredstehler @PtrTeixeira @ggs5427 @tkindy @Xcelled @suruuK  @jhaber @kmclarnon 