### PR TITLE
fix handling of scope and version when removing duplicate deps

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/FixDuplicateMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/FixDuplicateMojo.java
@@ -24,7 +24,6 @@ import javax.inject.Provider;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.io.ModelReader;
@@ -60,39 +59,91 @@ public class FixDuplicateMojo extends AnalyzeDuplicateMojo {
 
         List<String> pomLines = pomFileUtil.readPomFile();
 
-        List<Dependency> dependenciesToRemove = new ArrayList<>();
+        DuplicateDependenciesResult result = new DuplicateDependenciesResult();
 
         if (!duplicateDependencies.isEmpty()) {
-            dependenciesToRemove.addAll(
-                    findDuplicateDependencies(pomFileUtil.getDependencies(pomLines), duplicateDependencies));
-        }
-        if (!duplicateDependenciesManagement.isEmpty()) {
-            dependenciesToRemove.addAll(findDuplicateDependencies(
-                    pomFileUtil.getManagedDependencies(pomLines), duplicateDependenciesManagement));
+            result.add(findDuplicateDependencies(pomFileUtil.getDependencies(pomLines), duplicateDependencies));
         }
 
-        for (Dependency dep : PomFileUtil.sortByLineNumberDescending(dependenciesToRemove)) {
+        if (!result.dependenciesToUpdate.isEmpty()) {
+            int inserts = 0;
+            for (Dependency dep : PomFileUtil.sortByLineNumberDescending(result.dependenciesToUpdate)) {
+                inserts += pomFileUtil.updateDependency(dep, pomLines);
+            }
+
+            // re-resolve duplicate dependencies after making POM inserts
+            if (inserts > 0) {
+                result = new DuplicateDependenciesResult();
+                result.add(findDuplicateDependencies(pomFileUtil.getDependencies(pomLines), duplicateDependencies));
+            }
+        }
+
+        if (!duplicateDependenciesManagement.isEmpty()) {
+            // dep mgmt doesn't have scope, requires version
+            result.dependenciesToRemove.addAll(findDuplicateDependencies(
+                            pomFileUtil.getManagedDependencies(pomLines), duplicateDependenciesManagement)
+                    .dependenciesToRemove);
+        }
+
+        for (Dependency dep : PomFileUtil.sortByLineNumberDescending(result.dependenciesToRemove)) {
             pomFileUtil.removeDependency(dep, pomLines);
         }
 
         pomFileUtil.writePomFile(pomLines);
     }
 
-    private static List<Dependency> findDuplicateDependencies(List<Dependency> dependencies, Set<String> duplicates) {
-        List<Dependency> duplicateDependencies = new ArrayList<>();
+    private static DuplicateDependenciesResult findDuplicateDependencies(
+            List<Dependency> dependencies, Set<String> duplicates) {
+        DuplicateDependenciesResult result = new DuplicateDependenciesResult();
 
         for (String duplicate : duplicates) {
-            AtomicBoolean seenFirst = new AtomicBoolean();
+            List<Dependency> foundDuplicates = new ArrayList<>();
 
             for (Dependency dep : dependencies) {
                 if (dep.getManagementKey().equals(duplicate)) {
-                    if (seenFirst.getAndSet(true)) {
-                        duplicateDependencies.add(dep);
-                    }
+                    foundDuplicates.add(dep);
                 }
             }
+
+            String lastDefinedVersion = null;
+            String lastDefinedScope = null;
+
+            for (int i = foundDuplicates.size() - 1; i > 0; i--) {
+                Dependency dep = foundDuplicates.get(i);
+
+                lastDefinedVersion = dep.getVersion();
+                lastDefinedScope = dep.getScope();
+            }
+
+            Dependency depToRetain = foundDuplicates.remove(0);
+            if (lastDefinedVersion != null || isNotEmptyOrDefaultScope(lastDefinedScope)) {
+                if (lastDefinedVersion != null) {
+                    depToRetain.setVersion(lastDefinedVersion);
+                }
+                if (isNotEmptyOrDefaultScope(lastDefinedScope)) {
+                    depToRetain.setScope(lastDefinedScope);
+                }
+
+                result.dependenciesToUpdate.add(depToRetain);
+            }
+
+            result.dependenciesToRemove.addAll(foundDuplicates);
         }
 
-        return duplicateDependencies;
+        return result;
+    }
+
+    private static boolean isNotEmptyOrDefaultScope(String scope) {
+        return scope != null && !scope.equals("compile");
+    }
+
+    private static class DuplicateDependenciesResult {
+        private final List<Dependency> dependenciesToUpdate = new ArrayList<>();
+        private final List<Dependency> dependenciesToRemove = new ArrayList<>();
+
+        public void add(DuplicateDependenciesResult other) {
+            dependenciesToUpdate.addAll(other.dependenciesToUpdate);
+            dependenciesToRemove.addAll(other.dependenciesToRemove);
+        }
     }
 }

--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/FixMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/FixMojo.java
@@ -127,7 +127,7 @@ public class FixMojo extends AbstractAnalyzeMojo {
             keysToRemove.add(removal.getDependencyConflictId());
         }
 
-        for (Dependency dependency : getPomFileUtil().sortByLineNumberDescending(dependencies)) {
+        for (Dependency dependency : PomFileUtil.sortByLineNumberDescending(dependencies)) {
             if (keysToRemove.contains(dependency.getManagementKey())) {
                 getPomFileUtil().removeDependency(dependency, pomLines);
             }
@@ -147,36 +147,32 @@ public class FixMojo extends AbstractAnalyzeMojo {
 
         final int backupTestIndex;
         if (testDependencies.isEmpty() && nonTestDependencies.isEmpty()) {
-            Dependency lastDep = getPomFileUtil()
-                    .sortByLineNumberDescending(localDependencies)
-                    .get(0);
+            Dependency lastDep =
+                    PomFileUtil.sortByLineNumberDescending(localDependencies).get(0);
             backupTestIndex = lineIndexAfter(lastDep, pomLines);
         } else if (testDependencies.isEmpty()) {
-            Dependency lastDep = getPomFileUtil()
-                    .sortByLineNumberDescending(nonTestDependencies)
-                    .get(0);
+            Dependency lastDep =
+                    PomFileUtil.sortByLineNumberDescending(nonTestDependencies).get(0);
             backupTestIndex = lineIndexAfter(lastDep, pomLines);
         } else {
             Dependency firstTestDep =
-                    getPomFileUtil().sortByLineNumberAscending(testDependencies).get(0);
-            backupTestIndex = getPomFileUtil().startIndex(firstTestDep);
+                    PomFileUtil.sortByLineNumberAscending(testDependencies).get(0);
+            backupTestIndex = PomFileUtil.startIndex(firstTestDep);
         }
 
         final int backupNonTestIndex;
         if (testDependencies.isEmpty() && nonTestDependencies.isEmpty()) {
-            Dependency firstDep = getPomFileUtil()
-                    .sortByLineNumberAscending(localDependencies)
-                    .get(0);
+            Dependency firstDep =
+                    PomFileUtil.sortByLineNumberAscending(localDependencies).get(0);
             backupNonTestIndex = lineIndexAfter(firstDep, pomLines);
         } else if (nonTestDependencies.isEmpty()) {
             Dependency firstTestDep =
-                    getPomFileUtil().sortByLineNumberAscending(testDependencies).get(0);
-            backupNonTestIndex = getPomFileUtil().startIndex(firstTestDep);
+                    PomFileUtil.sortByLineNumberAscending(testDependencies).get(0);
+            backupNonTestIndex = PomFileUtil.startIndex(firstTestDep);
         } else {
-            Dependency firstNonTestDep = getPomFileUtil()
-                    .sortByLineNumberAscending(nonTestDependencies)
-                    .get(0);
-            backupNonTestIndex = getPomFileUtil().startIndex(firstNonTestDep);
+            Dependency firstNonTestDep =
+                    PomFileUtil.sortByLineNumberAscending(nonTestDependencies).get(0);
+            backupNonTestIndex = PomFileUtil.startIndex(firstNonTestDep);
         }
 
         // add test deps first to maintain line numbers since they go at the bottom
@@ -186,7 +182,7 @@ public class FixMojo extends AbstractAnalyzeMojo {
 
     private void addDependencies(
             Set<Artifact> additions, List<String> pomLines, List<Dependency> existing, int backupIndex) {
-        existing = getPomFileUtil().sortByLineNumberDescending(existing);
+        existing = PomFileUtil.sortByLineNumberDescending(existing);
 
         for (Artifact addition : sortByCoordinatesDescending(additions)) {
             boolean inserted = false;
@@ -209,10 +205,9 @@ public class FixMojo extends AbstractAnalyzeMojo {
                 if (matchingGroupId.isEmpty()) {
                     insertIndex = backupIndex;
                 } else {
-                    Dependency firstInGroup = getPomFileUtil()
-                            .sortByLineNumberAscending(matchingGroupId)
+                    Dependency firstInGroup = PomFileUtil.sortByLineNumberAscending(matchingGroupId)
                             .get(0);
-                    insertIndex = getPomFileUtil().startIndex(firstInGroup);
+                    insertIndex = PomFileUtil.startIndex(firstInGroup);
                 }
 
                 insertDependency(addition, insertIndex, pomLines);

--- a/src/main/java/org/apache/maven/plugins/dependency/utils/PomFileUtil.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/utils/PomFileUtil.java
@@ -27,9 +27,15 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.InputLocation;
 import org.apache.maven.model.InputSource;
@@ -39,6 +45,7 @@ import org.apache.maven.model.building.ModelSource;
 import org.apache.maven.model.building.StringModelSource;
 import org.apache.maven.model.io.ModelReader;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.utils.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +72,7 @@ public class PomFileUtil {
     }
 
     private Model rebuildModel(List<String> pomLines) {
-        String pom = StringUtils.join(pomLines, '\n');
+        String pom = String.join("\n", pomLines);
         ModelSource modelSource =
                 new StringModelSource(pom, project.get().getFile().getPath());
         InputSource inputSource = new InputSource();
@@ -86,6 +93,58 @@ public class PomFileUtil {
         inputSource.setLocation(project.get().getFile().getAbsolutePath());
 
         return model;
+    }
+
+    public int updateDependency(Dependency dependency, List<String> pomLines) {
+        int inserts = 0;
+        if (dependency.getVersion() != null) {
+            inserts += upsertLine(
+                    pomLines,
+                    "version",
+                    dependency.getVersion(),
+                    dependency.getLocation("version"),
+                    dependency.getLocation("artifactId"));
+        }
+        if (dependency.getScope() != null) {
+            inserts += upsertLine(
+                    pomLines,
+                    "scope",
+                    dependency.getScope(),
+                    dependency.getLocation("scope"),
+                    dependency.getLocation("classifier"),
+                    dependency.getLocation("version"),
+                    dependency.getLocation("artifactId"));
+        }
+
+        return inserts;
+    }
+
+    private int upsertLine(
+            List<String> pomLines,
+            String tag,
+            String value,
+            InputLocation replaceLocation,
+            InputLocation... appendLocations) {
+
+        if (replaceLocation != null) {
+            int indent = pomLines.get(replaceLocation.getLineNumber() - 1).indexOf("<");
+            pomLines.set(replaceLocation.getLineNumber() - 1, getIndentedLine(tag, value, indent));
+            return 0;
+        } else {
+            InputLocation appendLocation = Arrays.stream(appendLocations)
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Unable to find insert location in POM for tag: " + tag + " value: " + value));
+
+            int indent = pomLines.get(appendLocation.getLineNumber() - 1).indexOf("<");
+            pomLines.add(appendLocation.getLineNumber(), getIndentedLine(tag, value, indent));
+            return 1;
+        }
+    }
+
+    private String getIndentedLine(String tag, String value, int indent) {
+        return String.format("%s<%s>%s</%s>", StringUtils.repeat(" ", indent), tag, value, tag);
     }
 
     public void removeDependency(Dependency dependency, List<String> pomLines) {


### PR DESCRIPTION
We need to keep retaining the first instance of a duplicated dependency in the POM in order to preserve the dependency classpath ordering, but need to also retain the last instance of `<version>`, `<scope>`, as those attributes take precedence in the resolved dependency graph and removing a duplicate instance of those without transferring the attributes to the first instance will result in a different and incorrect dependency graph.

@PtrTeixeira 
