### PR TITLE
retain compile scope for duplicate deps

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/FixDuplicateMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/FixDuplicateMojo.java
@@ -23,6 +23,7 @@ import javax.inject.Provider;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.maven.model.Dependency;
@@ -112,18 +113,25 @@ public class FixDuplicateMojo extends AnalyzeDuplicateMojo {
                 Dependency dep = foundDuplicates.get(i);
 
                 lastDefinedVersion = dep.getVersion();
-                lastDefinedScope = dep.getScope();
+                lastDefinedScope = Optional.ofNullable(dep.getScope()).orElse("compile");
             }
 
             Dependency depToRetain = foundDuplicates.remove(0);
-            if (lastDefinedVersion != null || isNotEmptyOrDefaultScope(lastDefinedScope)) {
-                if (lastDefinedVersion != null) {
-                    depToRetain.setVersion(lastDefinedVersion);
-                }
-                if (isNotEmptyOrDefaultScope(lastDefinedScope)) {
-                    depToRetain.setScope(lastDefinedScope);
-                }
+            boolean needsUpdate = false;
 
+            if (lastDefinedVersion != null && !lastDefinedVersion.equals(depToRetain.getVersion())) {
+                depToRetain.setVersion(lastDefinedVersion);
+                needsUpdate = true;
+            }
+
+            if (!Optional.ofNullable(lastDefinedScope)
+                    .orElse("compile")
+                    .equals(Optional.ofNullable(depToRetain.getScope()).orElse("compile"))) {
+                depToRetain.setScope("compile".equals(lastDefinedScope) ? null : lastDefinedScope);
+                needsUpdate = true;
+            }
+
+            if (needsUpdate) {
                 result.dependenciesToUpdate.add(depToRetain);
             }
 

--- a/src/main/java/org/apache/maven/plugins/dependency/utils/PomFileUtil.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/utils/PomFileUtil.java
@@ -97,24 +97,20 @@ public class PomFileUtil {
 
     public int updateDependency(Dependency dependency, List<String> pomLines) {
         int inserts = 0;
-        if (dependency.getVersion() != null) {
-            inserts += upsertLine(
-                    pomLines,
-                    "version",
-                    dependency.getVersion(),
-                    dependency.getLocation("version"),
-                    dependency.getLocation("artifactId"));
-        }
-        if (dependency.getScope() != null) {
-            inserts += upsertLine(
-                    pomLines,
-                    "scope",
-                    dependency.getScope(),
-                    dependency.getLocation("scope"),
-                    dependency.getLocation("classifier"),
-                    dependency.getLocation("version"),
-                    dependency.getLocation("artifactId"));
-        }
+        inserts += upsertLine(
+                pomLines,
+                "scope",
+                dependency.getScope(),
+                dependency.getLocation("scope"),
+                dependency.getLocation("classifier"),
+                dependency.getLocation("version"),
+                dependency.getLocation("artifactId"));
+        inserts += upsertLine(
+                pomLines,
+                "version",
+                dependency.getVersion(),
+                dependency.getLocation("version"),
+                dependency.getLocation("artifactId"));
 
         return inserts;
     }
@@ -127,10 +123,15 @@ public class PomFileUtil {
             InputLocation... appendLocations) {
 
         if (replaceLocation != null) {
-            int indent = pomLines.get(replaceLocation.getLineNumber() - 1).indexOf("<");
-            pomLines.set(replaceLocation.getLineNumber() - 1, getIndentedLine(tag, value, indent));
-            return 0;
-        } else {
+            if (value == null) {
+                pomLines.remove(replaceLocation.getLineNumber() - 1);
+                return 1;
+            } else {
+                int indent = pomLines.get(replaceLocation.getLineNumber() - 1).indexOf("<");
+                pomLines.set(replaceLocation.getLineNumber() - 1, getIndentedLine(tag, value, indent));
+                return 0;
+            }
+        } else if (value != null) {
             InputLocation appendLocation = Arrays.stream(appendLocations)
                     .filter(Objects::nonNull)
                     .findFirst()
@@ -141,6 +142,7 @@ public class PomFileUtil {
             pomLines.add(appendLocation.getLineNumber(), getIndentedLine(tag, value, indent));
             return 1;
         }
+        return 0;
     }
 
     private String getIndentedLine(String tag, String value, int indent) {


### PR DESCRIPTION
Properly apply the compile scope for a duplicate dep's first instance, if present on the last instance.

e.g. 

```xml
<dependency>
  <groupId>foo</groupId>
  <artifactId>bar</artifactId>
  <scope>test</scope>
</dependency>
...
<dependency>
  <groupId>foo</groupId>
  <artifactId>bar</artifactId>
</dependency>
```

to:

```xml
<dependency>
  <groupId>foo</groupId>
  <artifactId>bar</artifactId>
</dependency>
...
- <dependency>
-  <groupId>foo</groupId>
-  <artifactId>bar</artifactId>
- </dependency>
```
