### PR TITLE
fix-duplicates should use scope from last duplicate instance in all cases

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/FixDuplicateMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/FixDuplicateMojo.java
@@ -107,13 +107,13 @@ public class FixDuplicateMojo extends AnalyzeDuplicateMojo {
             }
 
             String lastDefinedVersion = null;
-            String lastDefinedScope = null;
+            String lastDefinedScope = Optional.ofNullable(
+                            foundDuplicates.get(foundDuplicates.size() - 1).getScope())
+                    .orElse("compile");
 
             for (int i = foundDuplicates.size() - 1; i > 0; i--) {
                 Dependency dep = foundDuplicates.get(i);
-
                 lastDefinedVersion = dep.getVersion();
-                lastDefinedScope = Optional.ofNullable(dep.getScope()).orElse("compile");
             }
 
             Dependency depToRetain = foundDuplicates.remove(0);


### PR DESCRIPTION
Fixes detection of latest scope for a duplicate dependency.