### PR TITLE
Report version for unmanaged dependencies

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
@@ -560,11 +560,11 @@ public abstract class AbstractAnalyzeMojo extends AbstractMojo {
                 writer.writeText(artifact.getArtifactId());
                 writer.endElement();
                 String key = String.format(
-                        "%s:%s:%s:%s",
+                        "%s:%s:%s%s",
                         artifact.getGroupId(),
                         artifact.getArtifactId(),
                         artifact.getType(),
-                        (artifact.getClassifier() != null ? ":" : artifact.getClassifier()));
+                        (artifact.getClassifier() != null ? ":" + artifact.getClassifier() : ""));
                 if (!managedDependencies.contains(key)) {
                     writer.startElement("version");
                     writer.writeText(artifact.getBaseVersion());

--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
@@ -559,6 +559,17 @@ public abstract class AbstractAnalyzeMojo extends AbstractMojo {
                 writer.startElement("artifactId");
                 writer.writeText(artifact.getArtifactId());
                 writer.endElement();
+                String dependencyKey = String.format(
+                        "%s:%s:%s:%s",
+                        artifact.getGroupId(),
+                        artifact.getArtifactId(),
+                        artifact.getType(),
+                        (artifact.getClassifier() != null ? ":" : artifact.getClassifier()));
+                if (!managedDependencies.contains(dependencyKey)) {
+                    writer.startElement("version");
+                    writer.writeText(artifact.getBaseVersion());
+                    writer.endElement();
+                }
                 if (!managedDependencies.contains(artifact.getDependencyConflictId())) {
                     writer.startElement("version");
                     writer.writeText(artifact.getBaseVersion());

--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
@@ -559,13 +559,13 @@ public abstract class AbstractAnalyzeMojo extends AbstractMojo {
                 writer.startElement("artifactId");
                 writer.writeText(artifact.getArtifactId());
                 writer.endElement();
-                String dependencyKey = String.format(
+                String key = String.format(
                         "%s:%s:%s:%s",
                         artifact.getGroupId(),
                         artifact.getArtifactId(),
                         artifact.getType(),
                         (artifact.getClassifier() != null ? ":" : artifact.getClassifier()));
-                if (!managedDependencies.contains(dependencyKey)) {
+                if (!managedDependencies.contains(key)) {
                     writer.startElement("version");
                     writer.writeText(artifact.getBaseVersion());
                     writer.endElement();


### PR DESCRIPTION
Our dependency analyzer check is not reporting versions for unmanaged dependencies at the moment, which this gets picked up by SirJester as a suggested auto-fix, and this fails builds. I've added a check to add versions to unmanaged dependencies

@jaredstehler @PtrTeixeira @tkindy @Xcelled @stevie400 @suruuK 