### PR TITLE
Detect and remove redundant version tags from dependencies which are managed at same version

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -3,7 +3,7 @@ buildpack:
 
 env:
   SKIP_VERSION_OVERRIDE_ON_BRANCH: hubspot
-  MAVEN_ARGS: -Drat.skip=true
+  MAVEN_ARGS: -Drat.skip=true -Dspotless.check.skip=true
 
 
 stepActivation:

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -3,7 +3,7 @@ buildpack:
 
 env:
   SKIP_VERSION_OVERRIDE_ON_BRANCH: hubspot
-  MAVEN_ARGS: -DskipTests -Drat.skip=true -Dspotless.check.skip=true
+  MAVEN_ARGS: -Drat.skip=true
 
 
 stepActivation:

--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/AnalyzeDuplicateMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/AnalyzeDuplicateMojo.java
@@ -20,7 +20,12 @@ package org.apache.maven.plugins.dependency.analyze;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.maven.model.Dependency;
@@ -49,6 +54,9 @@ public class AnalyzeDuplicateMojo extends AbstractMojo {
 
     public static final String MESSAGE_DUPLICATE_DEP_IN_DEPMGMT =
             "List of duplicate dependencies defined in <dependencyManagement/> in your pom.xml:\n";
+
+    public static final String MESSAGE_REDUNDANT_VERSION_IN_DEPENDENCIES =
+            "List of redundant dependency versions defined in <dependencies/> in your pom.xml:\n";
 
     /**
      * Skip plugin execution completely.
@@ -87,6 +95,14 @@ public class AnalyzeDuplicateMojo extends AbstractMojo {
             duplicateDependencies = findDuplicateDependencies(model.getDependencies());
         }
 
+        Set<String> redundantDependencyVersions = Collections.emptySet();
+        if (model.getDependencies() != null
+                && project.getDependencyManagement() != null
+                && project.getDependencyManagement().getDependencies() != null) {
+            redundantDependencyVersions = findRedundantDependencyVersions(
+                    model.getDependencies(), project.getDependencyManagement().getDependencies());
+        }
+
         Set<String> duplicateDependenciesManagement = Collections.emptySet();
         if (model.getDependencyManagement() != null
                 && model.getDependencyManagement().getDependencies() != null) {
@@ -99,17 +115,21 @@ public class AnalyzeDuplicateMojo extends AbstractMojo {
 
             createMessage(duplicateDependencies, sb, MESSAGE_DUPLICATE_DEP_IN_DEPENDENCIES);
             createMessage(duplicateDependenciesManagement, sb, MESSAGE_DUPLICATE_DEP_IN_DEPMGMT);
+            createMessage(redundantDependencyVersions, sb, MESSAGE_REDUNDANT_VERSION_IN_DEPENDENCIES);
 
             if (sb.length() > 0) {
                 getLog().info(sb.toString());
-                handle(duplicateDependencies, duplicateDependenciesManagement);
+                handle(duplicateDependencies, duplicateDependenciesManagement, redundantDependencyVersions);
             } else {
                 getLog().info("No duplicate dependencies found in <dependencies/> or in <dependencyManagement/>");
             }
         }
     }
 
-    protected void handle(Set<String> duplicateDependencies, Set<String> duplicateDependenciesManagement) {
+    protected void handle(
+            Set<String> duplicateDependencies,
+            Set<String> duplicateDependenciesManagement,
+            Set<String> redundantDepdencyVersions) {
         // for subclasses to use
     }
 
@@ -138,5 +158,20 @@ public class AnalyzeDuplicateMojo extends AbstractMojo {
         modelDependencies2.removeIf(new HashSet<>(modelDependencies2)::remove);
         // keep a single instance of each duplicate
         return new LinkedHashSet<>(modelDependencies2);
+    }
+
+    private Set<String> findRedundantDependencyVersions(
+            List<Dependency> modelDependencies, List<Dependency> managedDependencies) {
+        List<String> modelDependencyVersions = modelDependencies.stream()
+                .filter(dep -> dep.getVersion() != null)
+                .map(dep -> dep.getManagementKey() + ":" + dep.getVersion())
+                .collect(Collectors.toList());
+        Set<String> managedDependencyVersions = managedDependencies.stream()
+                .map(dep -> dep.getManagementKey() + ":" + dep.getVersion())
+                .collect(Collectors.toSet());
+
+        modelDependencyVersions.removeIf(v -> !managedDependencyVersions.contains(v));
+
+        return new LinkedHashSet<>(modelDependencyVersions);
     }
 }

--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/FixDuplicateMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/FixDuplicateMojo.java
@@ -23,9 +23,11 @@ import javax.inject.Provider;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.io.ModelReader;
@@ -56,7 +58,10 @@ public class FixDuplicateMojo extends AnalyzeDuplicateMojo {
     private Provider<MavenProject> project;
 
     @Override
-    protected void handle(Set<String> duplicateDependencies, Set<String> duplicateDependenciesManagement) {
+    protected void handle(
+            Set<String> duplicateDependencies,
+            Set<String> duplicateDependenciesManagement,
+            Set<String> redundantDependencyVersions) {
         PomFileUtil pomFileUtil = new PomFileUtil(modelReader, project);
 
         List<String> pomLines = pomFileUtil.readPomFile();
@@ -89,6 +94,13 @@ public class FixDuplicateMojo extends AnalyzeDuplicateMojo {
 
         for (Dependency dep : PomFileUtil.sortByLineNumberDescending(result.dependenciesToRemove)) {
             pomFileUtil.removeDependency(dep, pomLines);
+        }
+
+        List<Dependency> redundantManagedVersions =
+                findRedundantManagedVersions(pomFileUtil.getDependencies(pomLines), redundantDependencyVersions);
+        if (!redundantManagedVersions.isEmpty()) {
+            PomFileUtil.sortByLineNumberDescending(redundantManagedVersions)
+                    .forEach(dep -> pomFileUtil.updateDependency(dep, pomLines));
         }
 
         pomFileUtil.writePomFile(pomLines);
@@ -136,8 +148,28 @@ public class FixDuplicateMojo extends AnalyzeDuplicateMojo {
         return result;
     }
 
-    private static boolean isNotEmptyOrDefaultScope(String scope) {
-        return scope != null && !scope.equals("compile");
+    private static List<Dependency> findRedundantManagedVersions(
+            List<Dependency> dependencies, Set<String> redundantDependencyVersions) {
+        Map<String, String> redundantDependencyVersionsByKey = redundantDependencyVersions.stream()
+                .map(dv -> {
+                    int split = dv.lastIndexOf(":");
+                    return new String[] {dv.substring(0, split), dv.substring(split + 1)};
+                })
+                .collect(Collectors.toMap(dv -> dv[0], dv -> dv[1]));
+
+        List<Dependency> depsToUpdate = new ArrayList<>();
+
+        for (Dependency dep : dependencies) {
+            if (dep.getVersion() != null) {
+                String version = redundantDependencyVersionsByKey.get(dep.getManagementKey());
+                if (version != null && version.equals(dep.getVersion())) {
+                    dep.setVersion(null);
+                    depsToUpdate.add(dep);
+                }
+            }
+        }
+
+        return depsToUpdate;
     }
 
     private static class DuplicateDependenciesResult {

--- a/src/test/java/org/apache/maven/plugins/dependency/analyze/TestAnalyzeDuplicateMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/analyze/TestAnalyzeDuplicateMojo.java
@@ -26,6 +26,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.dependency.AbstractDependencyMojoTestCase;
 import org.apache.maven.plugins.dependency.testUtils.stubs.DuplicateDependencies2ProjectStub;
+import org.apache.maven.plugins.dependency.testUtils.stubs.DuplicateDependencies3ProjectStub;
 import org.apache.maven.plugins.dependency.testUtils.stubs.DuplicateDependenciesProjectStub;
 import org.apache.maven.project.MavenProject;
 
@@ -72,60 +73,101 @@ public class TestAnalyzeDuplicateMojo extends AbstractDependencyMojoTestCase {
         assertTrue(log.getContent().contains("junit:junit:jar"));
     }
 
+    public void testDuplicate3() throws Exception {
+        MavenProject project = new DuplicateDependencies3ProjectStub();
+        getContainer().addComponent(project, MavenProject.class.getName());
+
+        MavenSession session = newMavenSession(project);
+        getContainer().addComponent(session, MavenSession.class.getName());
+
+        File testPom = new File(getBasedir(), "target/test-classes/unit/duplicate-dependencies/plugin-config3.xml");
+        AnalyzeDuplicateMojo mojo = (AnalyzeDuplicateMojo) lookupMojo("analyze-duplicate", testPom);
+        assertNotNull(mojo);
+        DuplicateLog log = new DuplicateLog();
+        mojo.setLog(log);
+        mojo.execute();
+
+        assertTrue(log.getContent()
+                .contains("List of redundant dependency versions defined in <dependencies/> in " + "your pom.xml"));
+        assertTrue(log.getContent().contains("junit:junit:jar:3.8.1"));
+    }
+
     static class DuplicateLog implements Log {
         StringBuilder sb = new StringBuilder();
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void debug(CharSequence content) {
             print("debug", content);
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void debug(CharSequence content, Throwable error) {
             print("debug", content, error);
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void debug(Throwable error) {
             print("debug", error);
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void info(CharSequence content) {
             print("info", content);
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void info(CharSequence content, Throwable error) {
             print("info", content, error);
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void info(Throwable error) {
             print("info", error);
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void warn(CharSequence content) {
             print("warn", content);
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void warn(CharSequence content, Throwable error) {
             print("warn", content, error);
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void warn(Throwable error) {
             print("warn", error);
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void error(CharSequence content) {
             System.err.println("[error] " + content.toString());
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void error(CharSequence content, Throwable error) {
             StringWriter sWriter = new StringWriter();
             PrintWriter pWriter = new PrintWriter(sWriter);

--- a/src/test/java/org/apache/maven/plugins/dependency/testUtils/stubs/DuplicateDependencies3ProjectStub.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/testUtils/stubs/DuplicateDependencies3ProjectStub.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.dependency.testUtils.stubs;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+/**
+ * very simple stub of maven project, going to take a lot of work to make it useful as a stub though
+ */
+public class DuplicateDependencies3ProjectStub extends MavenProjectStub {
+    public DuplicateDependencies3ProjectStub() {
+        File pom = new File(getBasedir(), "plugin-config3.xml");
+        MavenXpp3Reader pomReader = new MavenXpp3Reader();
+
+        try (FileInputStream in = new FileInputStream(pom)) {
+            Model model = pomReader.read(in);
+            setModel(model);
+
+            setGroupId(model.getGroupId());
+            setArtifactId(model.getArtifactId());
+            setVersion(model.getVersion());
+            setName(model.getName());
+            setUrl(model.getUrl());
+            setPackaging(model.getPackaging());
+            setFile(pom);
+
+        } catch (IOException | XmlPullParserException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public DependencyManagement getDependencyManagement() {
+        return getModel().getDependencyManagement();
+    }
+
+    /**
+     * @see MavenProjectStub#getBasedir()
+     */
+    public File getBasedir() {
+        return new File(super.getBasedir() + "/src/test/resources/unit/duplicate-dependencies");
+    }
+}

--- a/src/test/resources/unit/duplicate-dependencies/plugin-config3.xml
+++ b/src/test/resources/unit/duplicate-dependencies/plugin-config3.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+
+    <groupId>com.mycompany.app</groupId>
+    <artifactId>my-mojo</artifactId>
+    <packaging>maven-plugin</packaging>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>my-mojo Maven Mojo</name>
+    <url>http://maven.apache.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-plugin-api</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>3.8.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/unit/duplicate-dependencies/plugin-config3.xml
+++ b/src/test/resources/unit/duplicate-dependencies/plugin-config3.xml
@@ -19,53 +19,57 @@
   under the License.
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
 
-    <groupId>com.mycompany.app</groupId>
-    <artifactId>my-mojo</artifactId>
-    <packaging>maven-plugin</packaging>
-    <version>1.0-SNAPSHOT</version>
+  <groupId>com.mycompany.app</groupId>
+  <artifactId>my-mojo</artifactId>
+  <packaging>maven-plugin</packaging>
+  <version>1.0-SNAPSHOT</version>
 
-    <name>my-mojo Maven Mojo</name>
-    <url>http://maven.apache.org</url>
+  <name>my-mojo Maven Mojo</name>
+  <url>http://maven.apache.org</url>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-plugin-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>3.8.1</version>
-            <scope>test</scope>
-        </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-plugin-api</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>3.8.1</version>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>3.8.1</version>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-plugin-api</artifactId>
-            </dependency>
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>3.8.1</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <configuration>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
This adds detection to `dependency:analyze-duplicate` and fix to `dependency:fix-duplicate` to remove superfluous `<version>` tags from poms, where the dependency is managed at the same version.

@jaredstehler @PtrTeixeira @tkindy @Xcelled @stevie400 @suruuK