### PR TITLE
Add parameter to write fix output to separate file instead of in-place

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/FixDuplicateMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/FixDuplicateMojo.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.io.ModelReader;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.dependency.utils.PomFileUtil;
 import org.apache.maven.project.MavenProject;
 
@@ -46,6 +47,12 @@ import org.apache.maven.project.MavenProject;
  */
 @Mojo(name = "fix-duplicate", threadSafe = true)
 public class FixDuplicateMojo extends AnalyzeDuplicateMojo {
+
+    /**
+     * If true, write updated pom to this path instead of updating in place
+     */
+    @Parameter(property = "mdep.fix.outputFile", required = false)
+    private String outputFile;
 
     // TODO: could not get this working via sisu DI
     // @Component
@@ -62,7 +69,7 @@ public class FixDuplicateMojo extends AnalyzeDuplicateMojo {
             Set<String> duplicateDependencies,
             Set<String> duplicateDependenciesManagement,
             Set<String> redundantDependencyVersions) {
-        PomFileUtil pomFileUtil = new PomFileUtil(modelReader, project);
+        PomFileUtil pomFileUtil = new PomFileUtil(modelReader, project, outputFile);
 
         List<String> pomLines = pomFileUtil.readPomFile();
 

--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/FixMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/FixMojo.java
@@ -34,6 +34,7 @@ import org.apache.maven.model.InputLocation;
 import org.apache.maven.model.InputSource;
 import org.apache.maven.model.io.ModelReader;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.plugins.dependency.utils.PomFileUtil;
 import org.apache.maven.project.MavenProject;
@@ -63,6 +64,12 @@ public class FixMojo extends AbstractAnalyzeMojo {
 
     @Inject
     private Provider<MavenProject> project;
+
+    /**
+     * If true, write updated pom to this path instead of updating in place
+     */
+    @Parameter(property = "mdep.fix.outputFile", required = false)
+    private String outputFile;
 
     @Override
     protected boolean isFailOnWarning() {

--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/FixMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/FixMojo.java
@@ -54,6 +54,11 @@ import org.apache.maven.shared.utils.StringUtils;
  */
 @Mojo(name = "fix", requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
 public class FixMojo extends AbstractAnalyzeMojo {
+    /**
+     * If true, write updated pom to this path instead of updating in place
+     */
+    @Parameter(property = "mdep.fix.outputFile", required = false)
+    private String outputFile;
 
     // TODO: could not get this working via sisu DI
     // @Component
@@ -64,12 +69,6 @@ public class FixMojo extends AbstractAnalyzeMojo {
 
     @Inject
     private Provider<MavenProject> project;
-
-    /**
-     * If true, write updated pom to this path instead of updating in place
-     */
-    @Parameter(property = "mdep.fix.outputFile", required = false)
-    private String outputFile;
 
     @Override
     protected boolean isFailOnWarning() {
@@ -82,7 +81,7 @@ public class FixMojo extends AbstractAnalyzeMojo {
     }
 
     private PomFileUtil getPomFileUtil() {
-        return new PomFileUtil(modelReader, project);
+        return new PomFileUtil(modelReader, project, outputFile);
     }
 
     @Override

--- a/src/main/java/org/apache/maven/plugins/dependency/utils/PomFileUtil.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/utils/PomFileUtil.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.InputLocation;
@@ -57,10 +58,13 @@ public class PomFileUtil {
     private final ModelReader modelReader;
     private final Provider<MavenProject> project;
 
+    private final Optional<String> outputFile;
+
     @Inject
-    public PomFileUtil(ModelReader modelReader, Provider<MavenProject> project) {
+    public PomFileUtil(ModelReader modelReader, Provider<MavenProject> project, String outputFile) {
         this.modelReader = modelReader;
         this.project = project;
+        this.outputFile = Optional.ofNullable(outputFile);
     }
 
     public List<Dependency> getDependencies(List<String> pomLines) {
@@ -186,7 +190,7 @@ public class PomFileUtil {
     }
 
     public void writePomFile(List<String> pomLines) {
-        File pomFile = project.get().getFile();
+        File pomFile = outputFile.map(File::new).orElse(project.get().getFile());
         logger.info("Writing updated POM to {}", pomFile);
         PomFileUtil.writeLines(pomFile, pomLines);
     }


### PR DESCRIPTION
This adds a new optional parameter to write the output of `fix`, `fix-duplicate` goals to a separate file rather than in-place overwrite. Meant to be used in patch-generating workflows.